### PR TITLE
Remove obsolete delete_if_empty keys

### DIFF
--- a/shops_russia.xml
+++ b/shops_russia.xml
@@ -16,12 +16,12 @@
         <key key="brand" value="Ароматный мир" />
         <key key="name:en" value="Aromatny Mir" />
         <key key="name:ru" value="Ароматный мир" />
-        <combo key="contact:phone" text="Телефон" default="+7 495 7775190-xxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 495 7775190-xxxx" />
         <key key="contact:website" value="http://amwine.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/aromatny.mir" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Sa 09:30-22:30; Su 11:00-22:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Sa 09:30-22:30; Su 11:00-22:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://amwine.ru/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Dixy" ru.name="Дикси" type="node,closedway,multipolygon">
@@ -31,12 +31,12 @@
         <key key="brand" value="Дикси" />
         <key key="name:en" value="Dixy" />
         <key key="name:ru" value="Дикси" />
-        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" delete_if_empty="true" />
+        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" />
         <key key="contact:phone" value="+7 800 3330201" />
         <key key="contact:website" value="http://dixy.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="https://dixy.ru/nearest-shop/?region=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0&amp;city=&amp;street=&amp;op.x=39&amp;op.y=15&amp;form_build_id=form-MGrIV8_EYK6C5zSMV3QI1192m6i_XP6QI9Y_b5I477c&amp;form_id=dixy_shops_block_form" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Дикси_(сеть_магазинов)" />
         <key key="wikidata" value="Q4161561" />
@@ -52,9 +52,9 @@
         <key key="contact:phone" value="+7 800 1000804" />
         <key key="contact:website" value="http://www.krasnoeibeloe.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/krasnoe.beloe" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:05, Mo-Sa 09:30-22:30; Su 11:00-22:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:05, Mo-Sa 09:30-22:30; Su 11:00-22:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.krasnoeibeloe.ru/address" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Красное_&amp;_Белое" />
         <key key="wikidata" value="Q24933790" />
@@ -67,12 +67,12 @@
         <key key="name:en" value="Magnit" />
         <key key="name:ru" value="Магнит" />
         <key key="operator" value="ЗАО &quot;Тандер&quot;" />
-        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://magnit-info.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Su 09:30-22:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Su 09:30-22:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://magnit-info.ru/buyers/adds/1258/1305/418426" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Магнит_(сеть_магазинов)" />
         <key key="wikidata" value="Q940518" />
@@ -86,12 +86,12 @@
         <key key="name:en" value="Perekryostok" />
         <key key="name:ru" value="Перекресток" />
         <key key="alt_name" value="Перекрёсток" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://www.perekrestok.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/perekrestok" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.perekrestok.ru/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Перекрёсток_(сеть_магазинов)" />
         <key key="wikidata" value="Q1684639" />
@@ -103,12 +103,12 @@
         <key key="brand" value="Перекресток Экспресс" />
         <key key="name:en" value="Perekryostok Express" />
         <key key="name:ru" value="Перекресток Экспресс" />
-        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" delete_if_empty="true" />
+        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" />
         <key key="alt_name" value="Перекрёсток Экспресс" />
         <key key="contact:website" value="http://x5-express.ru/perekrestok_express" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Pyatyorochka" ru.name="Пятёрочка" type="node,closedway,multipolygon">
         <label text="Магазин &quot;Пятёрочка&quot;" />
@@ -117,14 +117,14 @@
         <key key="brand" value="Пятёрочка" />
         <key key="name:en" value="Pyatyorochka" />
         <key key="name:ru" value="Пятёрочка" />
-        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" delete_if_empty="true" />
+        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" />
         <key key="alt_name" value="Пятерочка" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="https://5ka.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/pyaterochka" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="https://5ka.ru/stores" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Пятёрочка" />
         <key key="wikidata" value="Q1768969" />
@@ -138,12 +138,12 @@
         <key key="name:ru" value="Суши Wok" />
         <key key="shop" value="convenience" />
         <key key="delivery" value="yes" />
-        <combo key="contact:phone" text="Телефон" default="+7 499 7544444" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 499 7544444" />
         <key key="contact:website" value="http://sushiwok.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/sushiwokofficial" />
-        <combo key="opening_hours" text="Время работы" default="Mo-Su 10:00-23:00" values="24/7, Mo-Su 10:00-23:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" default="Mo-Su 10:00-23:00" values="24/7, Mo-Su 10:00-23:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://sushiwok.ru/msk/addresses" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="U Palycha" ru.name="У Палыча" type="node,closedway,multipolygon">
@@ -154,11 +154,11 @@
         <key key="brand" value="У Палыча" />
         <key key="name:en" value="U Palycha" />
         <key key="name:ru" value="У Палыча" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://www.palich.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.palich.ru/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Fix price" ru.name="Фикс прайс" type="node,closedway,multipolygon">
@@ -170,9 +170,9 @@
         <key key="name:en" value="Fix price" />
         <key key="contact:phone" value="+7 800 7753515" />
         <key key="contact:website" value="http://www.fix-price.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Sa 09:00-20:00; Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.fix-price.ru/buyers/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Fix_Price_(сеть_магазинов)" />
         <key key="wikidata" value="Q4038791" />
@@ -187,16 +187,16 @@
         <key key="brand" value="IL Патио" />
         <key key="name:en" value="IL Patio" />
         <key key="name:ru" value="IL Патио" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://ilpatio.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/ilpatio.ru" />
         <key key="cuisine" value="italian" />
         <key key="diet:vegetarian" value="yes" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://ilpatio.ru/restaurants" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Fix_Price_(сеть_магазинов)" />
         <key key="wikidata" value="Q4038791" />
@@ -209,16 +209,16 @@
         <key key="brand" value="Баскин Роббинс" />
         <key key="name:en" value="Baskin-Robbins" />
         <key key="name:ru" value="Баскин Роббинс" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://baskinrobbins.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/BaskinRobbinsRussia" />
         <key key="cuisine" value="ice_cream" />
         <key key="diet:vegetarian" value="only" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://baskinrobbins.ru/?n=6" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Dunkin’_Brands" />
         <key key="wikidata" value="Q4037686" />
@@ -231,17 +231,17 @@
         <key key="brand" value="Бургер Кинг" />
         <key key="name:en" value="Burger King" />
         <key key="name:ru" value="Бургер Кинг" />
-        <combo key="contact:phone" text="Телефон" default="+7 495 5445000-xxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 495 5445000-xxxx" />
         <key key="contact:website" value="http://burgerking.ru"></key>
         <key key="contact:facebook" value="https://www.facebook.com/BurgerKingRussia" />
         <key key="cuisine" value="burger" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="drive_through" text="Есть ли обслуживание в машине?" disable_off="true" delete_if_empty="true" />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="drive_through" text="Есть ли обслуживание в машине?" disable_off="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://burgerking.ru/restaurants" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Burger_King" />
         <key key="wikidata" value="Q177054" />
@@ -254,14 +254,14 @@
         <key key="brand" value="Кофе Хауз" />
         <key key="name:en" value="Coffee House" />
         <key key="name:ru" value="Кофе Хауз" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://www.coffeehouse.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/coffeehouse.ru" />
         <key key="cuisine" value="coffee_shop" />
         <key key="diet:vegetarian" value="yes" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <key key="internet_access" value="wlan" />
         <key key="internet_access:fee" value="no" />
         <link href="http://coffeehouse.ru/adress" text="Ссылка на сайт (время работы, координаты и т.п.)" />
@@ -276,17 +276,17 @@
         <key key="name" value="KFC" />
         <key key="brand" value="KFC" />
         <key key="name:en" value="KFC" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://www.kfc.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/kfcrussia" />
         <key key="cuisine" value="chicken" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="drive_through" text="Есть ли обслуживание в машине?" disable_off="true" delete_if_empty="true" />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="drive_through" text="Есть ли обслуживание в машине?" disable_off="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://www.kfc.ru/restaurants" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:KFC" />
         <key key="wikidata" value="Q524757" />
@@ -299,15 +299,15 @@
         <key key="brand" value="Крошка Картошка" />
         <key key="name:en" value="Kroshka Kartoshka" />
         <key key="name:ru" value="Крошка Картошка" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://www.kartoshka.com" />
         <key key="cuisine" value="potato" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://www.kartoshka.com/contacts" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Крошка-картошка" />
         <key key="wikidata" value="Q4241838" />
@@ -320,14 +320,14 @@
         <key key="brand" value="Кружка" />
         <key key="name:en" value="Kruzhka" />
         <key key="name:ru" value="Кружка" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://www.kruzhka.ru" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 12:00-24:00; Sa,Su 00:00-04:00,12:00-24:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 12:00-24:00; Sa,Su 00:00-04:00,12:00-24:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://kruzhka.ru/addresses/map" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="McDonald's" ru.name="Макдоналдс" type="node,closedway,multipolygon">
@@ -339,17 +339,17 @@
         <key key="name:en" value="McDonald's" />
         <key key="name:ru" value="Макдоналдс" />
         <key key="alt_name" value="Макдональдс" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://www.mcdonalds.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/mcdonaldsrussia" />
         <key key="cuisine" value="burger" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 06:30-24:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 06:30-24:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="drive_through" text="Есть ли обслуживание в машине (McAuto)?" disable_off="true" delete_if_empty="true" />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="drive_through" text="Есть ли обслуживание в машине (McAuto)?" disable_off="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://www.mcdonalds.ru/restaurant/map?lat=55.752609&amp;lng=37.61699" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Макдоналдс" />
         <key key="wikidata" value="Q38076" />
@@ -362,16 +362,16 @@
         <key key="brand" value="Папа Джонс" />
         <key key="name:en" value="Papa John's" />
         <key key="name:ru" value="Папа Джонс" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="https://www.papajohns.ru" />
         <key key="cuisine" value="pizza" />
         <key key="diet:vegetarian" value="yes" />
         <key key="delivery" value="yes" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 11:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 11:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="https://www.papajohns.ru/adresa" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Subway" ru.name="Сабвэй" type="node,closedway,multipolygon">
@@ -382,15 +382,15 @@
         <key key="brand" value="Сабвэй" />
         <key key="name:en" value="Subway" />
         <key key="name:ru" value="Сабвэй" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://subway.ru" />
         <key key="cuisine" value="sandwich" />
         <key key="diet:vegetarian" value="yes" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://subway.ru/stores" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Subway_(сеть_ресторанов)" />
         <key key="wikidata" value="Q244457" />
@@ -403,16 +403,16 @@
         <key key="brand" value="Старбакс" />
         <key key="name:en" value="Starbucks" />
         <key key="name:ru" value="Старбакс" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://starbuckscoffee.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/StarbucksRussia" />
         <key key="cuisine" value="coffee_shop" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="https://www.facebook.com/StarbucksRussia/app_419559581405349" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Starbucks" />
         <key key="wikidata" value="Q37158" />
@@ -430,9 +430,9 @@
         <key key="contact:website" value="http://www.stardogs.ru" />
         <key key="cuisine" value="hotdog" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.stardogs.ru/default.aspx?page=address" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Стардог!s" />
         <key key="wikidata" value="Q4439856" />
@@ -450,11 +450,11 @@
         <key key="contact:facebook" value="https://www.facebook.com/teremok" />
         <key key="cuisine" value="crepe" />
         <key key="diet:vegetarian" value="yes" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://www.teremok.ru/address/msk/" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Теремок_(сеть_быстрого_питания)" />
         <key key="wikidata" value="Q4455593" />
@@ -467,16 +467,16 @@
         <key key="brand" value="Шоколадница" />
         <key key="name:en" value="Shokoladnitsa" />
         <key key="name:ru" value="Шоколадница" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://shoko.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/shoko.ru" />
         <key key="cuisine" value="coffee_shop" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true" />
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" />
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://shoko.ru/moskva/adresa_kofeen" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Russian appetite" ru.name="Русский Аппетит" type="node,closedway,multipolygon">
@@ -488,12 +488,12 @@
         <key key="brand" value="Русский Аппетит" />
         <key key="name:en" value="Russian appetite" />
         <key key="name:ru" value="Русский Аппетит" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://xn--80a4abej.xn--p1ai/" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="false" value_on="wlan" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="false" value_on="wlan" />
         <link href="http://xn--80a4abej.xn--p1ai/" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Robin Sdobin" ru.name="Робин Сдобин" type="node,closedway,multipolygon">
@@ -505,12 +505,12 @@
         <key key="brand" value="Робин Сдобин" />
         <key key="name:en" value="Robin Sdobin" />
         <key key="name:ru" value="Робин Сдобин" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://sdobin.ru/" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-23:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="false" value_on="wlan" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="false" value_on="wlan" />
         <link href="http://sdobin.ru/" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
     </group>
@@ -525,9 +525,9 @@
         <key key="contact:phone" value="+7 495 9797611" />
         <key key="contact:website" value="http://ru.tele2.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/TELE2Russia" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00, Mo-Su 10:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00, Mo-Su 10:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://msk.tele2.ru/help/service/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Tele2_Россия" />
         <key key="wikidata" value="Q4050799" />
@@ -544,9 +544,9 @@
         <key key="contact:phone" value="+7 800 7000611" />
         <key key="contact:website" value="http://moskva.beeline.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/Beelinerus" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00, Mo-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00, Mo-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://moskva.beeline.ru/customers/beeline-on-map/?lon=37.59401893881195&amp;lat=55.85027315163985&amp;zoom=11&amp;tab=offices&amp;filter=offices_filter_mobileService&amp;" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Билайн" />
         <key key="wikidata" value="Q402880" />
@@ -562,9 +562,9 @@
         <key key="name:ru" value="МегаФон" />
         <key key="contact:phone" value="+7 800 5500500" />
         <key key="contact:website" value="http://moscow.megafon.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://moscow.megafon.ru/help/offices/#offices" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Мегафон_(компания)" />
         <key key="wikidata" value="Q1720713" />
@@ -581,9 +581,9 @@
         <key key="contact:phone" value="+7 800 2500890" />
         <key key="contact:website" value="http://www.mts.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/mts" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.mts.ru/mobil_inet_and_tv/help/mts/offices" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:МТС_(компания)" />
         <key key="wikidata" value="Q1368919" />
@@ -599,9 +599,9 @@
         <key key="contact:phone" value="+7 800 7000010" />
         <key key="contact:website" value="http://euroset.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/euroset" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://euroset.ru/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Евросеть" />
         <key key="wikidata" value="Q65310" />
@@ -617,9 +617,9 @@
         <key key="contact:phone" value="+7 800 7005000" />
         <key key="contact:website" value="http://www.svyaznoy.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/svyaznoy.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.svyaznoy.ru/address_shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Связной_(компания)" />
         <key key="wikidata" value="Q65371" />
@@ -632,11 +632,11 @@
         <key key="shop" value="jewelry" />
         <key key="name" value="Pandora" />
         <key key="brand" value="Pandora" />
-        <combo key="contact:phone" text="Телефон" default="+7 495 2878838-xxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 495 2878838-xxx" />
         <key key="contact:website" value="http://www.pandora.net/ru-ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-22:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-22:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="https://www.pandora.net/ru-ru/stores" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Pandora_(ювелирный_дом)" />
         <key key="wikidata" value="Q2241604" />
@@ -649,11 +649,11 @@
         <key key="brand" value="Диана" />
         <key key="name:en" value="Diana" />
         <key key="name:ru" value="Диана" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://dryclean.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 10:00-20:00; Sa-Su 10:00-18:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 10:00-20:00; Sa-Su 10:00-18:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.dryclean.ru/priemnye_punkty" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Ile de Beaute" ru.name="Иль де Ботэ" type="node,closedway,multipolygon">
@@ -664,11 +664,11 @@
         <key key="brand" value="Иль де Ботэ" />
         <key key="name:en" value="Ile de Beaute" />
         <key key="name:ru" value="Иль де Ботэ" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://iledebeaute.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://iledebeaute.ru/company/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Lensmaster" ru.name="Линзмастер" type="node,closedway,multipolygon">
@@ -679,11 +679,11 @@
         <key key="brand" value="Линзмастер" />
         <key key="name:en" value="Lensmaster" />
         <key key="name:ru" value="Линзмастер" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://www.lensmaster.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Sa 10:00-21:00; Su 11:00-20:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Sa 10:00-21:00; Su 11:00-20:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.lensmaster.ru/saloni-optiki" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="L'etoile" ru.name="Л'Этуаль" type="node,closedway,multipolygon">
@@ -694,11 +694,11 @@
         <key key="brand" value="Л'Этуаль" />
         <key key="name:en" value="L'etoile" />
         <key key="name:ru" value="Л'Этуаль" />
-        <combo key="contact:phone" text="Телефон" default="+7 800 3337711-xxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 800 3337711-xxxx" />
         <key key="contact:website" value="http://www.letoile.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.letoile.ru/retail/?city=156&amp;map=yes" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Л'Этуаль" />
         <key key="wikidata" value="Q18400706" />
@@ -714,9 +714,9 @@
         <key key="contact:phone" value="+7 800 1001920" />
         <key key="contact:website" value="http://www.miuz.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/miuz.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.miuz.ru/stores/" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Persona" ru.name="Персона" type="node,closedway,multipolygon">
@@ -727,11 +727,11 @@
         <key key="brand" value="Персона" />
         <key key="name:en" value="Persona" />
         <key key="name:ru" value="Персона" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://www.persona.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.persona.ru/laboratories" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Eldorado" ru.name="Эльдорадо" type="node,closedway,multipolygon">
@@ -743,9 +743,9 @@
         <key key="name:ru" value="Эльдорадо" />
         <key key="contact:phone" value="+7 800 5551111" />
         <key key="contact:website" value="http://www.eldorado.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-21:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-21:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.eldorado.ru/info/shops/11324" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Эльдорадо_(сеть_магазинов)" />
         <key key="wikidata" value="Q4531492" />
@@ -761,10 +761,10 @@
         <key key="name:ru" value="Альфа-Банк" />
         <key key="contact:phone" value="+7 495 7888878" />
         <key key="contact:website" value="http://alfabank.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-21:00; Sa 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-21:00; Sa 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" />
         <link href="https://alfabank.ru/office/moscow/map/?kind=retail" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Альфа-банк" />
         <key key="wikidata" value="Q1377835" />
@@ -778,10 +778,10 @@
         <key key="name:ru" value="Банк Москвы" />
         <key key="contact:phone" value="+7 800 2002326" />
         <key key="contact:website" value="http://www.bm.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-20:00; Sa 10:00-17:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-20:00; Sa 10:00-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" />
         <link href="http://www.bm.ru/ru/ofisy-banka/otdelenija" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Банк_Москвы" />
         <key key="wikidata" value="Q767946" />
@@ -796,10 +796,10 @@
         <key key="operator" value="ВТБ 24 (ПАО)" />
         <key key="contact:phone" value="+7 800 1002424" />
         <key key="contact:website" value="http://www.vtb24.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-20:00; Sa 10:00-17:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-20:00; Sa 10:00-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" />
         <link href="http://www.vtb24.ru/pages/officesearch.aspx" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:ВТБ_24" />
         <key key="wikidata" value="Q4102033" />
@@ -813,10 +813,10 @@
         <key key="name:ru" value="Райффайзен" />
         <key key="contact:phone" value="+7 495 7219900" />
         <key key="contact:website" value="http://www.raiffeisen.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 10:00-20:00; Sa 10:00-17:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 10:00-20:00; Sa 10:00-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" />
         <link href="http://www.raiffeisen.ru/offices" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Райффайзенбанк" />
         <key key="wikidata" value="Q4389244" />
@@ -828,12 +828,12 @@
         <key key="name" value="Росбанк" />
         <key key="name:en" value="Rosbank" />
         <key key="name:ru" value="Росбанк" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://www.rosbank.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-20:00; Sa 09:00-17:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-20:00; Sa 09:00-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" />
         <link href="https://www.rosbank.ru/ru/offices" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Росбанк" />
         <key key="wikidata" value="Q1119857" />
@@ -845,13 +845,13 @@
         <key key="name" value="Сбербанк" />
         <key key="name:en" value="Sberbank" />
         <key key="name:ru" value="Сбербанк" />
-        <combo key="ref" text="Номер доп. офиса/опер. кассы" default="" delete_if_empty="true" />
+        <combo key="ref" text="Номер доп. офиса/опер. кассы" default="" />
         <key key="contact:phone" value="+7 800 5555550" />
         <key key="contact:website" value="http://www.sberbank.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:30-20:00; Sa 10:00-18:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:30-20:00; Sa 10:00-18:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="atm" text="Есть ли банкомат (если он с 24-часовым доступом, лучше отдельной точкой)?" disable_off="true" />
         <link href="http://www.sberbank.ru/ru/about/today/oib" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Сбербанк_России" />
         <key key="wikidata" value="Q205012" />
@@ -868,8 +868,8 @@
         <key key="contact:phone" value="+7 800 7077759" />
         <key key="contact:website" value="https://qiwi.com" />
         <link href="http://oriflamepro.ru/img/qiwi-terminali.JPG" text="Фотография-пример" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" delete_if_empty="true" />
-        <combo key="ref" text="Номер терминала" delete_if_empty="true"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" />
+        <combo key="ref" text="Номер терминала"></combo>
         <link href="https://qiwi.com/replenish/map.action?owners=1&amp;lng=55.73421489447054&amp;zoom=13" text="Ссылка на сайт (время работы, номера терминалов)" />
         <key key="wikipedia" value="ru:Сбербанк_России" />
         <key key="wikidata" value="Q205012" />
@@ -886,8 +886,8 @@
         <key key="contact:phone" value="+7 495 7774888" />
         <key key="contact:website" value="http://mkb.ru" />
         <link href="https://mkb.ru/images/facility/private_person/payment_outgoing/terminal_right.png" text="Фотография-пример" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" delete_if_empty="true" />
-        <combo key="ref" text="Номер терминала" delete_if_empty="true"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" />
+        <combo key="ref" text="Номер терминала"></combo>
         <link href="http://mkb.ru/about_bank/address/?type=terminal" text="Ссылка на сайт (время работы, номера терминалов)" />
       </item>
     </group>
@@ -899,12 +899,12 @@
         <key key="healthcare" value="pharmacy" />
         <key key="name" value="36,6" />
         <key key="brand" value="36,6" />
-        <combo key="contact:phone" text="Телефон" default="+7 495 7978686-xxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 495 7978686-xxxx" />
         <key key="contact:website" value="http://www.366.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" />
         <link href="http://www.366.ru/pharmacies.html" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:36,6_(аптечная_сеть)" />
         <key key="wikidata" value="Q226889" />
@@ -918,12 +918,12 @@
         <key key="brand" value="А5" />
         <key key="name:en" value="A5" />
         <key key="name:ru" value="А5" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://apteka5.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" />
         <link href="http://apteka5.ru/list_of_pharmacies" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Gorzdrav" ru.name="Горздрав" type="node,closedway,multipolygon">
@@ -936,10 +936,10 @@
         <key key="name:ru" value="Горздрав" />
         <key key="contact:phone" value="+7 499 6536277" />
         <key key="contact:website" value="http://www.gorzdrav.org" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" />
         <link href="http://www.gorzdrav.org/apteka/items" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Orteka" ru.name="Ортека" type="node,closedway,multipolygon">
@@ -952,9 +952,9 @@
         <key key="name:ru" value="Ортека" />
         <key key="contact:phone" value="+7 495 7755000" />
         <key key="contact:website" value="http://www.orteka.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00, Mo-Fr 09:00-20:00; Sa 10:00-20:00; Su 10:00-19:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00, Mo-Fr 09:00-20:00; Sa 10:00-20:00; Su 10:00-19:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.orteka.ru/salon" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Rigla" ru.name="Ригла" type="node,closedway,multipolygon">
@@ -966,12 +966,12 @@
         <key key="brand" value="Ригла" />
         <key key="name:en" value="Rigla" />
         <key key="name:ru" value="Ригла" />
-        <combo key="contact:phone" text="Телефон" default="+7 495 2311697-xxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 495 2311697-xxxx" />
         <key key="contact:website" value="http://www.rigla.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" />
         <link href="http://www.rigla.ru/stores" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Ригла" />
         <key key="wikidata" value="Q4394431" />
@@ -985,12 +985,12 @@
         <key key="brand" value="Столички" />
         <key key="name:en" value="Stolichki" />
         <key key="name:ru" value="Столички" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://stolichki.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" />
         <link href="http://stolichki.ru/stores/moscow_region" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="CMD" type="node,closedway,multipolygon">
@@ -1005,9 +1005,9 @@
         <key key="name:en" value="CMD" />
         <key key="contact:phone" value="+7 495 7880001" />
         <key key="contact:website" value="http://www.cmd-online.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.cmd-online.ru/about/contact" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Gemotest" ru.name="Гемотест" type="node,closedway,multipolygon">
@@ -1023,9 +1023,9 @@
         <key key="name:ru" value="Гемотест" />
         <key key="contact:phone" value="+7 495 5321313" />
         <key key="contact:website" value="http://www.gemotest.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.gemotest.ru/address/select/maps.php" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Invitro" ru.name="Инвитро" type="node,closedway,multipolygon">
@@ -1041,9 +1041,9 @@
         <key key="name:ru" value="Инвитро" />
         <key key="contact:phone" value="+7 495 3630363" />
         <key key="contact:website" value="https://www.invitro.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="https://www.invitro.ru/offices/moscow" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Независимая_лаборатория_Инвитро" />
         <key key="wikidata" value="Q4200546" />
@@ -1054,13 +1054,13 @@
         <label text="Военкомат" />
         <space />
         <key key="military" value="office" />
-        <combo key="name" text="Наименование" default="N-ский военкомат" delete_if_empty="true" />
-        <combo key="official_name" text="Полное официальное наименование подразделения" default="N-ский военный комиссариат N-ской области" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="name" text="Наименование" default="N-ский военкомат" />
+        <combo key="official_name" text="Полное официальное наименование подразделения" default="N-ский военный комиссариат N-ской области" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://mil.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <key key="wikipedia" value="ru:Военный_комиссариат" />
         <key key="wikidata" value="Q460254" />
       </item>
@@ -1069,13 +1069,13 @@
         <space />
         <key key="office" value="government" />
         <key key="government" value="register_office" />
-        <combo key="name" text="Наименование" default="N-ское управление ЗАГС" delete_if_empty="true" />
-        <combo key="official_name" text="Полное официальное наименование подразделения" default="N-ское управление ЗАГС N-ской области" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" delete_if_empty="true" />
+        <combo key="name" text="Наименование" default="N-ское управление ЗАГС" />
+        <combo key="official_name" text="Полное официальное наименование подразделения" default="N-ское управление ЗАГС N-ской области" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <key key="wikipedia" value="ru:ЗАГС" />
         <key key="wikidata" value="Q745221" />
       </item>
@@ -1084,64 +1084,64 @@
         <space />
         <key key="office" value="government" />
         <key key="government" value="treasury" />
-        <combo key="name" text="Наименование подразделения" default="Отдел № ... Управления Федерального казначейства" delete_if_empty="true" />
-        <combo key="official_name" text="Полное наименование подразделения" default="Отдел № ... Управления Федерального казначейства по ... ской области" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="name" text="Наименование подразделения" default="Отдел № ... Управления Федерального казначейства" />
+        <combo key="official_name" text="Полное наименование подразделения" default="Отдел № ... Управления Федерального казначейства по ... ской области" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://roskazna.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Миграционная служба" type="node,closedway,multipolygon">
         <label text="Управление/отделение ФМС" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="migration" />
-        <combo key="name" text="Наименование подразделения" default="Управление по вопросам миграции ГУ МВД России по г. n / n-скому району" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true"></combo>
+        <combo key="name" text="Наименование подразделения" default="Управление по вопросам миграции ГУ МВД России по г. n / n-скому району" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Налоговая инспекция" type="node,closedway,multipolygon">
         <label text="Налоговая инспекция (инспекция ФНС)" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="tax" />
-        <combo key="name" text="Наименование подразделения" default="ФНС России по г. ... ской области" delete_if_empty="true" />
-        <combo key="official_name" text="Полное официальное наименование подразделения" default="Инспекция Федеральной налоговой службы России по г. ... ской области" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="name" text="Наименование подразделения" default="ФНС России по г. ... ской области" />
+        <combo key="official_name" text="Полное официальное наименование подразделения" default="Инспекция Федеральной налоговой службы России по г. ... ской области" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://www.nalog.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Пенсионный фонд" type="node,closedway,multipolygon">
         <label text="Пенсионный фонд (отделение, клиентская служба)" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="pension_fund" />
-        <combo key="name" text="Наименование подразделения" default="Главное управление ПФР №  по г. Москве и Московской области, Управление № " delete_if_empty="true" />
-        <combo key="official_name" text="Полное официальное наименование подразделения" default="Главное управление Пенсионного фонда России №  по г. Москве и Московской области, Управление №" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="name" text="Наименование подразделения" default="Главное управление ПФР №  по г. Москве и Московской области, Управление № " />
+        <combo key="official_name" text="Полное официальное наименование подразделения" default="Главное управление Пенсионного фонда России №  по г. Москве и Московской области, Управление №" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://www.pfrf.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Почта России" type="node,closedway,multipolygon">
         <label text="Почтовое отделение ФГУП «Почта России»" />
         <space />
         <key key="amenity" value="post_office" />
         <key key="operator" value="ФГУП «Почта России»" />
-        <combo key="name" text="Наименование отделения связи" default="Отделение связи №" delete_if_empty="true" />
-        <combo key="ref" text="Номер отделения связи (ref)" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="name" text="Наименование отделения связи" default="Отделение связи №" />
+        <combo key="ref" text="Номер отделения связи (ref)" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://www.russianpost.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="https://pochta.ru/offices" text="Ссылка на сайт (время работы, координаты и т.п.)" />
         <key key="wikipedia" value="ru:Почта_России" />
         <key key="wikidata" value="Q1502763" />
@@ -1151,100 +1151,100 @@
         <space />
         <key key="office" value="government" />
         <key key="government" value="prosecutor" />
-        <combo key="name" text="Наименование подразделения" default="Прокуратура n-ского района/области" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" default="http://www.genproc.gov.ru" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="name" text="Наименование подразделения" default="Прокуратура n-ского района/области" />
+        <combo key="contact:website" text="Веб-сайт" default="http://www.genproc.gov.ru" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Следственный комитет" type="node,closedway,multipolygon">
         <label text="Следственный комитет" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="investigation" />
-        <combo key="name" text="Наименование подразделения" default="Следственный комитет n-ского района/области" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" default="http://sledcom.ru" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="name" text="Наименование подразделения" default="Следственный комитет n-ского района/области" />
+        <combo key="contact:website" text="Веб-сайт" default="http://sledcom.ru" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Служба гос. статистики" type="node,closedway,multipolygon">
         <label text="Служба гос. статистики" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="statistics" />
-        <combo key="name" text="Наименование подразделения" default="Отдел государственной статистики в N-ском районе" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" default="http://www.gks.ru" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="name" text="Наименование подразделения" default="Отдел государственной статистики в N-ском районе" />
+        <combo key="contact:website" text="Веб-сайт" default="http://www.gks.ru" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Служба соц. защиты" type="node,closedway,multipolygon">
         <label text="Служба соц. защиты" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="social_services" />
-        <combo key="name" text="Наименование подразделения" default="Отдел социальной защиты населения N-ского района" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="name" text="Наименование подразделения" default="Отдел социальной защиты населения N-ского района" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Управление образования" type="node,closedway,multipolygon">
         <label text="Управление образования" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="education" />
-        <combo key="name" text="Наименование подразделения" default="Управление образования N-ского района" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" delete_if_empty="true" />
+        <combo key="name" text="Наименование подразделения" default="Управление образования N-ского района" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-12:30,13:15-18:00; Fr 09:00-12:30,13:15-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Центр гигиены и эпидемиологии (б. СЭС)" type="node,closedway,multipolygon">
         <label text="Центр гигиены и эпидемиологии (б. СЭС)" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="healthcare" />
-        <combo key="name" text="Наименование" default="Центр гигиены и эпидемиологии по N-скому району" delete_if_empty="true" />
-        <combo key="official_name" text="Полное официальное наименование подразделения" default="Федеральное бюджетное учреждение здравоохранения &quot;Центр гигиены и эпидемиологии по N-скому району&quot;" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" delete_if_empty="true" />
+        <combo key="name" text="Наименование" default="Центр гигиены и эпидемиологии по N-скому району" />
+        <combo key="official_name" text="Полное официальное наименование подразделения" default="Федеральное бюджетное учреждение здравоохранения &quot;Центр гигиены и эпидемиологии по N-скому району&quot;" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Центр госуслуг" type="node,closedway,multipolygon">
         <label text="Центр госуслуг" />
         <space />
         <key key="amenity" value="public_service" />
         <key key="office" value="government" />
-        <combo key="name" text="Наименование" default="Центр госуслуг n-ского района" delete_if_empty="true" />
-        <combo key="official_name" text="Полное официальное наименование подразделения" default="Многофункциональный центр предоставления государственных и муниципальных услуг n-ского района" delete_if_empty="true" />
+        <combo key="name" text="Наименование" default="Центр госуслуг n-ского района" />
+        <combo key="official_name" text="Полное официальное наименование подразделения" default="Многофункциональный центр предоставления государственных и муниципальных услуг n-ского района" />
         <key key="alt_name" value="Мои документы" />
-        <combo key="contact:website" text="Веб-сайт" values="http://md.mos.ru" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" values="http://md.mos.ru" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Центр занятости" type="node,closedway,multipolygon">
         <label text="Центр занятости (фонд занятости, биржа труда)" />
         <space />
         <key key="office" value="government" />
         <key key="government" value="recruitment" />
-        <combo key="name" text="Наименование" default="Центр занятости населения" delete_if_empty="true" />
-        <combo key="official_name" text="Полное официальное наименование подразделения" default="Государственное казенное учреждение &quot;...ский центр занятости населения&quot;" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" delete_if_empty="true" />
+        <combo key="name" text="Наименование" default="Центр занятости населения" />
+        <combo key="official_name" text="Полное официальное наименование подразделения" default="Государственное казенное учреждение &quot;...ский центр занятости населения&quot;" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Центр социального обслуживания" type="node,closedway,multipolygon">
         <label text="Центр социального обслуживания (инвалидов, пожилых)" />
@@ -1252,13 +1252,13 @@
         <key key="amenity" value="social_facility" />
         <key key="social_facility" value="outreach" />
         <key key="social_facility:for" value="disabled;senior" />
-        <combo key="name" text="Наименование" default="Территориальный центр социального обслуживания &quot;...&quot;" delete_if_empty="true" />
-        <combo key="official_name" text="Полное официальное наименование подразделения" default="Государственное бюджетное учреждение Территориальный центр социального обслуживания &quot;...&quot;" delete_if_empty="true" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-20:00; Fr 09:00-18:45; Sa 09:00-17:00" delete_if_empty="true" />
+        <combo key="name" text="Наименование" default="Территориальный центр социального обслуживания &quot;...&quot;" />
+        <combo key="official_name" text="Полное официальное наименование подразделения" default="Государственное бюджетное учреждение Территориальный центр социального обслуживания &quot;...&quot;" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-20:00; Fr 09:00-18:45; Sa 09:00-17:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
     </group>
     <group name="Медицинские учреждения">
@@ -1270,11 +1270,11 @@
         <key key="health_facility:type" value="hospital" />
         <key key="medical_system:western" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <label text=" " />
         <label text="Если больница специализированная (например, глазная)," />
         <label text="укажите специализацию (для глазной health_specialty:ophthalmology=main)" />
@@ -1287,18 +1287,18 @@
         <key key="healthcare" value="clinic" />
         <key key="health_facility:type" value="clinic" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <label text=" " />
         <label text="Медицинская система (по умолчанию современная западная):" />
-        <combo key="medical_system:western" text="Cовременная западная" default="yes" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="medical_system:ayurveeda" text="Аюрведа" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="medical_system:homeopathy" text="Гомеопатия" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="medical_system:chinese" text="Китайская традиционная" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="medical_system:tibetan" text="Тибетская традиционная" values="yes, no" delete_if_empty="true"></combo>
+        <combo key="medical_system:western" text="Cовременная западная" default="yes" values="yes, no"></combo>
+        <combo key="medical_system:ayurveeda" text="Аюрведа" values="yes, no"></combo>
+        <combo key="medical_system:homeopathy" text="Гомеопатия" values="yes, no"></combo>
+        <combo key="medical_system:chinese" text="Китайская традиционная" values="yes, no"></combo>
+        <combo key="medical_system:tibetan" text="Тибетская традиционная" values="yes, no"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <label text=" "></label>
         <label text="Если клиника специализированная (например, онкологическая)," />
         <label text="укажите специализацию (для огкологической health_specialty:oncology=main)" />
@@ -1311,18 +1311,18 @@
         <key key="healthcare" value="doctor" />
         <key key="health_facility:type" value="office" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <label text=" " />
         <label text="Медицинская система (по умолчанию современная западная):" />
-        <combo key="medical_system:western" text="Cовременная западная" default="yes" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="medical_system:ayurveeda" text="Аюрведа" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="medical_system:homeopathy" text="Гомеопатия" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="medical_system:chinese" text="Китайская традиционная" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="medical_system:tibetan" text="Тибетская традиционная" values="yes, no" delete_if_empty="true"></combo>
+        <combo key="medical_system:western" text="Cовременная западная" default="yes" values="yes, no"></combo>
+        <combo key="medical_system:ayurveeda" text="Аюрведа" values="yes, no"></combo>
+        <combo key="medical_system:homeopathy" text="Гомеопатия" values="yes, no"></combo>
+        <combo key="medical_system:chinese" text="Китайская традиционная" values="yes, no"></combo>
+        <combo key="medical_system:tibetan" text="Тибетская традиционная" values="yes, no"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <label text=" "></label>
         <label text="Если кабинет специализированный (например, гастроэнтерологический)," />
         <label text="укажите специализацию (для гастроэнтерологии health_specialty:gastroenterology=main)" />
@@ -1338,11 +1338,11 @@
         <key key="health_specialty:gynaecology" value="main" />
         <key key="provided_for:female" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Laboratory" ru.name="Лаборатория" type="node,closedway,multipolygon">
         <label text="Лаборатория (анализы и т.п.)" />
@@ -1353,11 +1353,11 @@
         <key key="medical_system:western" value="yes" />
         <key key="health_specialty:microbiology" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Rehab" ru.name="Реабелитационный центр" type="node,closedway,multipolygon">
         <label text="Реабелитационный центр" />
@@ -1367,11 +1367,11 @@
         <key key="health_facility:type" value="rehabilitation" />
         <key key="medical_system:western" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <label text=" "></label>
         <label text="Если реабелитационный центр специализированный (например, наркологический)," />
         <label text="укажите специализацию (для наркологии health_specialty:addiction_medicine=main)" />
@@ -1387,11 +1387,11 @@
         <key key="health_specialty:gynaecology" value="main" />
         <key key="provided_for:female" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Sanatorium" ru.name="Санаторий" type="node,closedway,multipolygon">
         <label text="Санаторий (с лечебной специализацией)" />
@@ -1402,11 +1402,11 @@
         <key key="health_facility:type" value="therapy" />
         <key key="medical_system:western" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <label text=" "></label>
         <label text="Если санаторий специализированный (например, кардиологический)," />
         <label text="укажите специализацию (для кардиологии health_specialty:cardiology=main)" />
@@ -1418,15 +1418,15 @@
         <key key="amenity" value="dentist" />
         <key key="healthcare" value="dentist" />
         <key key="health_facility:type" value="clinic" />
-        <combo key="health_facility:type" text="Клиника или кабинет стоматолога" values="clinic, doctors" delete_if_empty="true" />
+        <combo key="health_facility:type" text="Клиника или кабинет стоматолога" values="clinic, doctors" />
         <key key="medical_system:western" value="yes" />
         <key key="health_specialty:dentistry" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Ambulance station" ru.name="Станция скорой помощи" type="node,closedway,multipolygon">
         <label text="Станция скорой помощи" />
@@ -1437,11 +1437,11 @@
         <key key="medical_system:western" value="yes" />
         <key key="health_specialty:emergency" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="First-aid center" ru.name="Травмпункт" type="node,closedway,multipolygon">
         <label text="Травмпункт" />
@@ -1452,11 +1452,11 @@
         <key key="medical_system:western" value="yes" />
         <key key="health_specialty:traumatology" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Hospice" ru.name="Хоспис" type="node,closedway,multipolygon">
         <label text="Хоспис" />
@@ -1467,11 +1467,11 @@
         <key key="medical_system:western" value="yes" />
         <key key="health_specialty:palliative" value="yes" />
         <text key="name" text="Название" />
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
     </group>
     <group name="Образовательные учреждения">
@@ -1484,11 +1484,11 @@
         <key key="education_profile:general" value="yes" />
         <key key="education_level:preschool" value="yes" />
         <text key="name" text="Название" />
-        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
+        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Primary school" ru.name="Начальная школа" type="node,closedway,multipolygon">
         <label text="Начальная школа" />
@@ -1500,11 +1500,11 @@
         <key key="education_level:primary" value="yes" />
         <key key="education_form:fulltime" value="yes" />
         <text key="name" text="Название" />
-        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
+        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="School" ru.name="Общеобразовательная школа" type="node,closedway,multipolygon">
         <label text="Общеобразовательная школа (лицей, гимназия)" />
@@ -1520,18 +1520,18 @@
         <label text=" " />
         <space />
         <label text="Школы с углублённым изучением:" />
-        <combo key="education_profile:mathematics" text="математики" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="education_profile:physics" text="физики" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="education_profile:chemistry" text="химии" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="education_profile:biology" text="биологии" values="yes, no" delete_if_empty="true"></combo>
-        <combo key="education_profile:languages" text="языков" values="yes, no" delete_if_empty="true"></combo>
+        <combo key="education_profile:mathematics" text="математики" values="yes, no"></combo>
+        <combo key="education_profile:physics" text="физики" values="yes, no"></combo>
+        <combo key="education_profile:chemistry" text="химии" values="yes, no"></combo>
+        <combo key="education_profile:biology" text="биологии" values="yes, no"></combo>
+        <combo key="education_profile:languages" text="языков" values="yes, no"></combo>
         <label text="Для языковых спецшкол добавьте тег education_programme:EN/ES/DE/FR...=yes" />
         <label text=" " />
-        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
+        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="College" ru.name="Колледж, ПТУ, техникум" type="node,closedway,multipolygon">
         <label text="Колледж, ПТУ, техникум" />
@@ -1542,14 +1542,14 @@
         <key key="education_profile:professional" value="yes" />
         <key key="education_level:secondary" value="yes" />
         <text key="name" text="Название" />
-        <check key="education_form:fulltime" text="Дневная форма обучения" disable_off="true" delete_if_empty="true" />
-        <check key="education_form:parttime" text="Вечерняя форма обучения" disable_off="true" delete_if_empty="true" />
-        <check key="education_form:external" text="Заочная форма обучения" disable_off="true" delete_if_empty="true" />
-        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
+        <check key="education_form:fulltime" text="Дневная форма обучения" disable_off="true" />
+        <check key="education_form:parttime" text="Вечерняя форма обучения" disable_off="true" />
+        <check key="education_form:external" text="Заочная форма обучения" disable_off="true" />
+        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="University" ru.name="ВУЗ" type="node,closedway,multipolygon">
         <label text="ВУЗ (университет, институт, академия)" />
@@ -1560,14 +1560,14 @@
         <key key="education_profile:professional" value="yes" />
         <key key="education_level:higher" value="yes" />
         <text key="name" text="Название" />
-        <check key="education_form:fulltime" text="Дневная форма обучения" disable_off="true" delete_if_empty="true" />
-        <check key="education_form:parttime" text="Вечерняя форма обучения" disable_off="true" delete_if_empty="true" />
-        <check key="education_form:external" text="Заочная форма обучения" disable_off="true" delete_if_empty="true" />
-        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
+        <check key="education_form:fulltime" text="Дневная форма обучения" disable_off="true" />
+        <check key="education_form:parttime" text="Вечерняя форма обучения" disable_off="true" />
+        <check key="education_form:external" text="Заочная форма обучения" disable_off="true" />
+        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private"></combo>
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Sport school" ru.name="Спортивная школа" type="node,closedway,multipolygon">
         <label text="Спортивная школа (ДЮСШ, ДЮСШОР)" />
@@ -1580,12 +1580,12 @@
         <key key="education_level:primary" value="yes" />
         <key key="education_form:parttime" value="yes" />
         <text key="name" text="Название" />
-        <combo key="sport" text="Вид спорта" delete_if_empty="true" />
-        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
+        <combo key="sport" text="Вид спорта" />
+        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Music school" ru.name="Музыкальная школа" type="node,closedway,multipolygon">
         <label text="Музыкальная школа" />
@@ -1597,11 +1597,11 @@
         <key key="education_level:primary" value="yes" />
         <key key="education_form:parttime" value="yes" />
         <text key="name" text="Название" />
-        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
+        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Art school" ru.name="Художественная школа" type="node,closedway,multipolygon">
         <label text="Художественная школа (школа искусств)" />
@@ -1614,11 +1614,11 @@
         <key key="education_level:primary" value="yes" />
         <key key="education_form:parttime" value="yes" />
         <text key="name" text="Название" />
-        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
+        <combo key="ownership" text="Форма собственности (по умолчанию - государственная)" default="state" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Driving school" ru.name="Автошкола" type="node,closedway,multipolygon">
         <label text="Автошкола" />
@@ -1630,12 +1630,12 @@
         <key key="education_level:primary" value="yes" />
         <key key="education_form:parttime" value="yes" />
         <text key="name" text="Название" />
-        <combo key="ownership" text="Форма собственности" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="ownership" text="Форма собственности" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
       <item name="Language school" ru.name="Курсы/школа иностранного языка" type="node,closedway,multipolygon">
         <label text="Курсы/школа иностранного языка" />
@@ -1647,19 +1647,19 @@
         <key key="education_form:parttime" value="yes" />
         <text key="name" text="Название" />
         <label text="Языки:" />
-        <check key="education_programme:EN" text="английский" disable_off="true" delete_if_empty="true" />
-        <check key="education_programme:ES" text="испанский" disable_off="true" delete_if_empty="true" />
-        <check key="education_programme:IT" text="итальянский" disable_off="true" delete_if_empty="true" />
-        <check key="education_programme:ZH" text="китайский" disable_off="true" delete_if_empty="true" />
-        <check key="education_programme:DE" text="немецкий" disable_off="true" delete_if_empty="true" />
-        <check key="education_programme:FR" text="французский" disable_off="true" delete_if_empty="true" />
+        <check key="education_programme:EN" text="английский" disable_off="true" />
+        <check key="education_programme:ES" text="испанский" disable_off="true" />
+        <check key="education_programme:IT" text="итальянский" disable_off="true" />
+        <check key="education_programme:ZH" text="китайский" disable_off="true" />
+        <check key="education_programme:DE" text="немецкий" disable_off="true" />
+        <check key="education_programme:FR" text="французский" disable_off="true" />
         <label text=" " />
-        <combo key="ownership" text="Форма собственности" values="state, private" delete_if_empty="true"></combo>
-        <combo key="contact:website" text="Веб-сайт" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true"></combo>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" delete_if_empty="true" />
+        <combo key="ownership" text="Форма собственности" values="state, private"></combo>
+        <combo key="contact:website" text="Веб-сайт" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-22:00, Mo-Fr 07:30-19:30; Sa-Su 07:30-14:30" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
       </item>
     </group>
     <group name="Городская инфраструктура">
@@ -1672,16 +1672,16 @@
         <key key="covered" value="no" />
         <key key="supervised" value="no" />
         <key key="opening_hours" value="24/7" />
-        <combo key="capacity" text="Вместимость (за каждую стойку можно прицепить два велика)" delete_if_empty="true" />
+        <combo key="capacity" text="Вместимость (за каждую стойку можно прицепить два велика)" />
       </item>
       <item name="WC" ru.name="Городской туалет" type="node,closedway,multipolygon">
         <label text="Общ. туалет" />
         <space />
         <key key="amenity" value="toilets" />
-        <text key="name" text="Название"  delete_if_empty="true" />
-        <text key="operator" text="Компания-оператор" delete_if_empty="true" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" delete_if_empty="true" />
-        <check key="fee" text="Платный" default="off"  delete_if_empty="true" />
+        <text key="name" text="Название"  />
+        <text key="operator" text="Компания-оператор" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" />
+        <check key="fee" text="Платный" default="off"  />
         <key key="toilets:disposal" value="flush" />
         <key key="toilets:position" value="seated" />
       </item>
@@ -1690,9 +1690,9 @@
         <space />
         <key key="amenity" value="post_box" />
         <key key="operator" value="Почта России" />
-        <combo key="ref" text="Инвентарный номер ящика" delete_if_empty="true"></combo>
-        <combo key="collection_times" text="Время выемки писем" values="Mo-Su 05:00,14:10, Mo-Fr 05:00,14:10; Sa 09:15; Su 14:10" delete_if_empty="true" />
-        <check key="drive_through" text="Можно ли положить письмо не выходя из авто?" disable_off="true" delete_if_empty="true" />
+        <combo key="ref" text="Инвентарный номер ящика"></combo>
+        <combo key="collection_times" text="Время выемки писем" values="Mo-Su 05:00,14:10, Mo-Fr 05:00,14:10; Sa 09:15; Su 14:10" />
+        <check key="drive_through" text="Можно ли положить письмо не выходя из авто?" disable_off="true" />
       </item>
       <item name="Delivery terminal InPost " ru.name="Почтомат InPost (бывш. QIWI Post)" type="node">
         <label text="Почтомат InPost (бывш. QIWI Post)" />
@@ -1706,8 +1706,8 @@
         <key key="payment:debit_cards" value="yes" />
         <key key="contact:phone" value="+7 800 3335146" />
         <key key="contact:website" value="https://inpost.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" delete_if_empty="true" />
-        <combo key="ref" text="Номер терминала" delete_if_empty="true"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" />
+        <combo key="ref" text="Номер терминала"></combo>
         <link href="https://inpost.ru/ru/customers/nayti-blizhaishiy-terminal" text="Ссылка на сайт (время работы, номера почтоматов)" />
       </item>
       <item name="Rostelecom pay phone" ru.name="Телефон Ростелеком" type="node">
@@ -1728,7 +1728,7 @@
         <key key="railway" value="ventilation_shaft" />
         <key key="service" value="ventilation" />
         <text key="name" text="Название" />
-        <combo key="ref" text="Номер" delete_if_empty="true" />
+        <combo key="ref" text="Номер" />
       </item>
       <item name="Gas substation" ru.name="Газорегуляторный пункт" type="node,closedway,multipolygon">
         <label text="Газорегуляторный пункт" />
@@ -1737,16 +1737,16 @@
         <key key="substation" value="distribution" />
         <key key="substance" value="gas" />
         <link href="http://wikimapia.org/27936916/ru/%D0%A8%D0%BA%D0%B0%D1%84%D0%BD%D0%BE%D0%B9-%D0%B3%D0%B0%D0%B7%D0%BE%D1%80%D0%B5%D0%B3%D1%83%D0%BB%D1%8F%D1%82%D0%BE%D1%80%D0%BD%D1%8B%D0%B9-%D0%BF%D1%83%D0%BD%D0%BA%D1%82-%D0%A8%D0%A0%D0%9F-33#/photo/3438334" text="Фотография-пример" />
-        <combo key="operator" text="Компания-оператор" delete_if_empty="true"></combo>
-        <combo key="ref" text="Номер" delete_if_empty="true"></combo>
+        <combo key="operator" text="Компания-оператор"></combo>
+        <combo key="ref" text="Номер"></combo>
       </item>
       <item name="Sewage pumping station" ru.name="Канализационная насосная станция" type="node,closedway,multipolygon">
         <label text="Канализационная насосная станция" />
         <space />
         <key key="man_made" value="pumping_station" />
         <key key="pumping_station" value="sewage" />
-        <combo key="operator" text="Компания-оператор" delete_if_empty="true"></combo>
-        <combo key="ref" text="Номер" delete_if_empty="true"></combo>
+        <combo key="operator" text="Компания-оператор"></combo>
+        <combo key="ref" text="Номер"></combo>
       </item>
       <item name="Communication mast" ru.name="Мачта сотовой связи" type="node">
         <label text="Мачта сотовой связи (распространены в городах)" />
@@ -1755,8 +1755,8 @@
         <key key="mast:type" value="communication" />
         <key key="communication:mobile_phone" value="yes" />
         <link href="https://atlas.mos.ru/?lang=ru&amp;z=7&amp;ll=37.558189324321624%2C55.867183329454164&amp;pa=21.8&amp;pp=37.55817898%2C55.86718489" text="Фотография-пример" />
-        <combo key="operator" text="Компания-оператор" delete_if_empty="true"></combo>
-        <combo key="height" text="Высота (в метрах)" delete_if_empty="true"></combo>
+        <combo key="operator" text="Компания-оператор"></combo>
+        <combo key="height" text="Высота (в метрах)"></combo>
       </item>
       <item name="Communication mast" ru.name="Башня сотовой связи" type="node">
         <label text="Башня сотовой связи (распространены в сельской местности" />
@@ -1765,8 +1765,8 @@
         <key key="tower:type" value="communication" />
         <key key="communication:mobile_phone" value="yes" />
         <link href="https://www.google.ru/maps/@55.8245367,36.9184932,3a,75y,263.57h,116.88t/data=!3m6!1e1!3m4!1smAWF8VNFYQHed3GZ0W0SYA!2e0!7i13312!8i6656" text="Фотография-пример" />
-        <combo key="operator" text="Компания-оператор" delete_if_empty="true"></combo>
-        <combo key="height" text="Высота (в метрах)" delete_if_empty="true"></combo>
+        <combo key="operator" text="Компания-оператор"></combo>
+        <combo key="height" text="Высота (в метрах)"></combo>
       </item>
       <item name="Local heat substation" ru.name="Центр./индивид. тепловой пункт" type="node,closedway,multipolygon">
         <label text="Центральный/индивидуальный тепловой пункт" />
@@ -1778,7 +1778,7 @@
         <key key="location" value="indoor" />
         <key key="substation" value="distribution" />
         <key key="man_made" value="heat_exchange_station" />
-        <combo key="operator" text="Компания-оператор" delete_if_empty="true"></combo>
+        <combo key="operator" text="Компания-оператор"></combo>
       </item>
       <item name="Local power substation" ru.name="Электроподстанция" type="node,closedway,multipolygon">
         <label text="Электроподстанция (локальная)" />
@@ -1786,10 +1786,10 @@
         <key key="building" value="service" />
         <key key="building:levels" value="1" />
         <key key="power" value="substation" />
-        <combo key="location" text="Расположение (будка, в здании)" values="indoor, kiosk" delete_if_empty="true" />
+        <combo key="location" text="Расположение (будка, в здании)" values="indoor, kiosk" />
         <key key="substation" value="minor_distribution" />
-        <combo key="operator" text="Компания-оператор" delete_if_empty="true"></combo>
-        <combo key="ref" text="Номер" delete_if_empty="true"></combo>
+        <combo key="operator" text="Компания-оператор"></combo>
+        <combo key="ref" text="Номер"></combo>
       </item>
     </group>
   </group>

--- a/shops_russia_moscow_region.xml
+++ b/shops_russia_moscow_region.xml
@@ -17,9 +17,9 @@
         <key key="shop" value="convenience" />
         <key key="contact:phone" value="+7 495 6638602" />
         <key key="contact:website" value="http://vkusvill.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://vkusvill.ru/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Izbyonka" ru.name="Избёнка" type="node,closedway,multipolygon">
@@ -32,9 +32,9 @@
         <key key="shop" value="dairy" />
         <key key="contact:phone" value="+7 495 6638602" />
         <key key="contact:website" value="http://vkusvill.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://vkusvill.ru/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="Magnoliya" ru.name="Магнолия" type="node,closedway,multipolygon">
@@ -44,12 +44,12 @@
         <key key="brand" value="Магнолия" />
         <key key="name:en" value="Magnoliya" />
         <key key="name:ru" value="Магнолия" />
-        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" delete_if_empty="true" />
-        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" delete_if_empty="true" />
+        <combo key="shop" text="Тип магазина (если есть тележки на колесах - супермаркет)" values="supermarket, convenience" default="supermarket" />
+        <combo key="contact:phone" text="Телефон" default="+7 ххх ххххххх" />
         <key key="contact:website" value="http://www.mgnl.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.mgnl.ru/shops" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
     </group>
@@ -66,11 +66,11 @@
         <key key="contact:website" value="http://glowsubs.ru" />
         <key key="cuisine" value="sandwich" />
         <key key="diet:vegetarian" value="no" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 10:00-22:00, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan" delete_if_empty="true"></check>
-        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="internet_access" text="Есть ли Wi-Fi?" disable_off="true" value_on="wlan"></check>
+        <check key="internet_access:fee" text="Wi-Fi предоставляется бесплатно?" disable_off="true" value_on="no" />
         <link href="http://glowsubs.ru/restaurants" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
     </group>
@@ -85,9 +85,9 @@
         <key key="name:ru" value="Мобил Элемент" />
         <key key="contact:phone" value="+7 495 6467803" />
         <key key="contact:website" value="http://www.mobilelement.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-22:30, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 08:00-22:30, Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.mobilelement.ru/map" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
     </group>
@@ -100,11 +100,11 @@
         <key key="name" value="Ticketland.ru" />
         <key key="brand" value="Ticketland.ru" />
         <key key="operator" value="ООО «МДТЗК»" />
-        <combo key="contact:phone" text="Телефон" default="+7 903 xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 903 xxxxxxx" />
         <key key="contact:website" value="http://www.ticketland.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
         <link href="http://www.ticketland.ru/kassa" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
       <item name="InfoPayment terminal Mosinfo" ru.name="Справочно-платежный терминал Мосинфо" type="node">
@@ -119,8 +119,8 @@
         <key key="contact:phone" value="+7 495 7774888" />
         <key key="contact:website" value="http://www.giss.ru" />
         <link href="https://prv1.lori-images.net/0007456673-middle.jpg" text="Фотография-пример" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" delete_if_empty="true" />
-        <combo key="ref" text="Номер терминала" delete_if_empty="true"></combo>
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00" />
+        <combo key="ref" text="Номер терминала"></combo>
         <link href="http://www.giss.ru/#/objects/mit" text="Ссылка на сайт (время работы, номера терминалов)" />
       </item>	  
     </group>
@@ -134,12 +134,12 @@
         <key key="brand" value="Самсон Фарма" />
         <key key="name:en" value="Samson Pharma" />
         <key key="name:ru" value="Самсон Фарма" />
-        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" delete_if_empty="true" />
+        <combo key="contact:phone" text="Телефон" default="+7 xxx xxxxxxx" />
         <key key="contact:website" value="http://www.samson-f.ru" />
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <space />
-        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" delete_if_empty="true" />
-        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" delete_if_empty="true" />
+        <check key="wheelchair" text="Есть ли доступ для инвалидной коляски?" disable_off="true" />
+        <check key="dispensing" text="Есть ли продажа лекарств по рецептам?" disable_off="true" />
         <link href="http://www.samson-f.ru/info.aspx?id=10" text="Ссылка на сайт (время работы, координаты и т.п.)" />
       </item>
     </group>
@@ -170,7 +170,7 @@
         <key key="name" value="Проездные билеты"></key>
         <key key="name:en" value="Public transport tickets"></key>
         <key key="contact:website" value="http://www.mosgortrans.ru"></key>
-        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" delete_if_empty="true" />
+        <combo key="opening_hours" text="Время работы" values="24/7, Mo-Su 09:00-21:00, Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00, Mo-Th 09:00-13:00,13:45-17:00; Fr 09:00-13:00,13:45-15:45" />
         <key key="operator" value="ГУП «Мосгортранс»" />
       </item>
       <item name="Moscow Parking meter" ru.name="Паркомат (Москва)" type="node">
@@ -184,7 +184,7 @@
         <key key="payment:debit_cards" value="yes" />
         <key key="contact:phone" value="+7 495 5395454" />
         <key key="contact:website" value="http://parking.mos.ru" />
-        <combo key="ref" text="Номер паркомата" delete_if_empty="true" />
+        <combo key="ref" text="Номер паркомата" />
         <key key="opening_hours" value="24/7" />
         <link href="http://parking.mos.ru" text="Ссылка на сайт (номера паркоматов)" />
       </item>


### PR DESCRIPTION
Ключ `delete_if_empty="true"` [не работает](https://josm.openstreetmap.de/wiki/TaggingPresets#DeprecatedAttributes) уже 4 года. Посносил его.