### PR TITLE
remove invalid characters

### DIFF
--- a/russian_shops.xml
+++ b/russian_shops.xml
@@ -3033,7 +3033,7 @@
         <key key="contact:facebook" value="https://www.facebook.com/parking.mos.ru" />
         <key key="contact:twitter" value="https://twitter.com/parking_mos_ru" />
         <text key="ref" text="Номер паркомата" />
-        <key key="opening_hours" value="24/7" />``
+        <key key="opening_hours" value="24/7" />
         <link href="http://parking.mos.ru" text="Ссылка на сайт (номера паркоматов)" />
       </item>
       <item name="Postbox (Russian Post)" ru.name="Почтовый ящик (Почта России)" type="node">


### PR DESCRIPTION
causes parsing error with JOSM: 
`org.xml.sax.SAXParseException; lineNumber: 3038; columnNumber: 14; cvc-complex-type.2.3: Element 'item' cannot have character [children], because the type's content type is element-only.`

See https://josm.openstreetmap.de/jenkins/job/JOSM-Integration/lastCompletedBuild/jdk=JDK8/testReport/org.openstreetmap.josm.gui.preferences.map/TaggingPresetPreferenceTestIT/testValidityOfAvailablePresets/