### PR TITLE
Обновление сайта МТС и vk Связного

### DIFF
--- a/russian_shops.xml
+++ b/russian_shops.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0"
   author="literan and others"
-  version="2.0_2018-03-23_1"
+  version="2.0_2018-03-25_1"
   link="https://github.com/ruosm-presets/literan-moscow"
   icon="https://upload.wikimedia.org/wikipedia/commons/d/db/Twemoji_1f1f7-1f1fa.svg"
   shortdescription="Russian POIs"
@@ -1589,7 +1589,7 @@
         <key key="contact:phone" value="+7 800 2500890" />
         <key key="contact:twitter" value="https://twitter.com/ru_mts" />
         <key key="contact:vk" value="https://vk.com/mts" />
-        <key key="contact:website" value="https://shop.mts.ru" />
+        <key key="contact:website" value="http://www.mts.ru" />
         <key key="name" value="МТС" />
         <key key="name:en" value="MTS" />
         <key key="name:ru" value="МТС" />

--- a/russian_shops.xml
+++ b/russian_shops.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0"
   author="literan and others"
-  version="2.0_2018-03-18_1"
+  version="2.0_2018-03-23_1"
   link="https://github.com/ruosm-presets/literan-moscow"
   icon="https://upload.wikimedia.org/wikipedia/commons/d/db/Twemoji_1f1f7-1f1fa.svg"
   shortdescription="Russian POIs"

--- a/russian_shops.xml
+++ b/russian_shops.xml
@@ -1589,13 +1589,13 @@
         <key key="contact:phone" value="+7 800 2500890" />
         <key key="contact:twitter" value="https://twitter.com/ru_mts" />
         <key key="contact:vk" value="https://vk.com/mts" />
-        <key key="contact:website" value="http://www.mts.ru" />
+        <key key="contact:website" value="https://shop.mts.ru" />
         <key key="name" value="МТС" />
         <key key="name:en" value="MTS" />
         <key key="name:ru" value="МТС" />
         <key key="office" value="telecommunication" />
         <key key="shop" value="mobile_phone" />
-        <link href="http://www.mts.ru/mobil_inet_and_tv/help/mts/offices" text="Official website (place locator)" ru.text="Ссылка на сайт (часы работы, координаты и т.п.)" />
+        <link href="https://shop.mts.ru/stores/" text="Official website (place locator)" ru.text="Ссылка на сайт (часы работы, координаты и т.п.)" />
         <reference ref="level_wheelchair_address" />
       </item>
       <item name="Svyaznoy" ru.name="Связной" type="node,closedway,multipolygon" preset_name_label="true" icon="https://upload.wikimedia.org/wikipedia/ru/f/fa/SvyaznoyLogo.png">

--- a/russian_shops.xml
+++ b/russian_shops.xml
@@ -1606,7 +1606,7 @@
         <key key="brand:wikipedia" value="ru:Связной (компания)" />
         <key key="contact:facebook" value="https://www.facebook.com/svyaznoy.ru" />
         <key key="contact:phone" value="+7 800 7005000" />
-        <key key="contact:vk" value="https://vk.com/club11445015" />
+        <key key="contact:vk" value="https://vk.com/svyaznoy" />
         <key key="contact:website" value="https://www.svyaznoy.ru" />
         <key key="name" value="Связной" />
         <key key="name:ru" value="Связной" />


### PR DESCRIPTION
У МТС я взял shop.mts.ru в качестве сайта, потому что именно на нём информация о салонах.