### PR TITLE
Заменил substance=heat на 'hot_water' для ЦТП

### DIFF
--- a/russian_shops.xml
+++ b/russian_shops.xml
@@ -3658,7 +3658,7 @@
         <key key="location" value="indoor" />
         <key key="man_made" value="heat_exchange_station" />
         <key key="pipeline" value="substation" />
-        <key key="substance" value="heat" />
+        <key key="substance" value="hot_water" />
         <key key="substation" value="distribution" />
         <preset_link preset_name="Address" />
       </item>


### PR DESCRIPTION
В вики пишут что substance=heat устарел и предлагают заменить на steam или hot_water. Поскольку паровое отопление в России редкость, предлагаю в заготовке для ЦТП использовать hot_water. 

https://wiki.openstreetmap.org/wiki/Key:substance