### PR TITLE
Добавление тегов brand:wikidata и brand:wikipedia

### DIFF
--- a/russian_shops.xml
+++ b/russian_shops.xml
@@ -227,6 +227,7 @@
         <combo key="contact:phone" text="Phone number" default="+7 800 7550003" />
         <key key="amenity" value="pharmacy" />
         <combo key="brand" text="Brand" values="Вита,Вита Экспресс,Вита Центральная" />
+        <key key="brand:wikidata" value="Q109810737" />
         <key key="contact:instagram" value="https://www.instagram.com/vita_express/" />
         <key key="contact:vk" value="https://vk.com/aptekivita" />
         <key key="contact:website" value="https://vitaexpress.ru" />
@@ -241,6 +242,7 @@
         <combo key="contact:phone" text="Phone number" values="+7 499 6536277,+7 812 4261584" default="+7 499 6536277" />
         <key key="amenity" value="pharmacy" />
         <key key="brand" value="Горздрав" />
+        <key key="brand:wikidata" value="Q126363868" />
         <key key="contact:email" value="info@gor-zdrav.ru" />
         <key key="contact:ok" value="https://ok.ru/group/57486617870381" />
         <key key="contact:vk" value="https://vk.com/gorzdrav" />
@@ -255,6 +257,8 @@
         <combo key="contact:phone" text="Phone number" default="+7 495 7907711" />
         <key key="amenity" value="pharmacy" />
         <key key="brand" value="Еаптека" />
+        <key key="brand:wikidata" value="Q110253378" />
+        <key key="brand:wikipedia" value="ru:Еаптека" />
         <key key="contact:telegram" value="https://t.me/formamag" />
         <key key="contact:vk" value="https://vk.com/eaptekaru" />
         <key key="contact:website" value="https://www.eapteka.ru" />
@@ -268,6 +272,7 @@
         <space />
         <key key="amenity" value="pharmacy" />
         <key key="brand" value="Живика" />
+        <key key="brand:wikidata" value="Q123165954" />
         <key key="contact:email" value="info@aptekazhivika.ru" />
         <key key="contact:website" value="http://zhivika.ru" />
         <key key="contact:ok" value="https://ok.ru/aptekazhivika" />
@@ -285,6 +290,7 @@
     <combo key="contact:phone" text="Phone number" default="+7 800 500 92 62" />
     <key key="amenity" value="pharmacy" />
     <key key="brand" value="Здравсити" />
+    <key key="brand:wikidata" value="Q120261818" />
     <key key="contact:telegram" value="https://t.me/zdravcity_official" />
     <key key="contact:vk" value="https://vk.com/zdravcity" />
     <key key="contact:website" value="https://zdravcity.ru" />
@@ -298,6 +304,7 @@
         <space />
         <key key="amenity" value="pharmacy" />
         <key key="brand" value="Магнит Аптека" />
+        <key key="brand:wikidata" value="Q120262563" />
         <combo key="contact:phone" text="Phone number" default="+7 800 2007803" />
         <key key="contact:website" value="https://apteka.magnit.ru/" />
         <key key="healthcare" value="pharmacy" />
@@ -326,6 +333,8 @@
         <combo key="contact:phone" text="Phone number" values="+7 495 7755000" default="+7 800 3333112" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 09:00-22:00,Mo-Fr 09:00-21:00; Sa-Su 10:00-19:00,Mo-Fr 09:00-20:00; Sa 10:00-20:00; Su 10:00-19:00" />
         <key key="brand" value="Ортека" />
+        <key key="brand:wikidata" value="Q62393660" />
+        <key key="brand:wikipedia" value="ru:Ортека" />
         <key key="contact:facebook" value="https://www.facebook.com/orteka.rus" />
         <key key="contact:instagram" value="https://www.instagram.com/orteka_rus" />
         <key key="contact:vk" value="https://vk.com/orteka_ru" />
@@ -392,6 +401,7 @@
         <combo key="contact:phone" text="Phone number" default="+7 800 5551115" />
         <key key="amenity" value="pharmacy" />
         <key key="brand" value="Столички" />
+        <key key="brand:wikidata" value="Q109717665" />
         <key key="contact:vk" value="https://vk.com/stolichki_official" />
         <key key="contact:website" value="https://stolichki.ru" />
         <key key="healthcare" value="pharmacy" />
@@ -405,6 +415,7 @@
         <reference ref="phone" />
         <key key="amenity" value="pharmacy" />
         <key key="brand" value="Столичные аптеки" />
+        <key key="brand:wikidata" value="Q139555187" />
         <key key="contact:email" value="info@sapteki.ru" />
         <key key="contact:website" value="https://www.sapteki.ru" />
         <key key="healthcare" value="pharmacy" />
@@ -442,6 +453,7 @@
         <combo key="contact:phone" text="Phone number" values="+7 495 5321313" default="+7 800 5501313" />
         <key key="amenity" value="doctors" />
         <key key="brand" value="Гемотест" />
+        <key key="brand:wikidata" value="Q123377862" />
         <key key="contact:email" value="client@gemotest.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/gemotestlab" />
         <key key="contact:ok" value="https://ok.ru/gemotest" />
@@ -604,6 +616,8 @@
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-22:00,Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <key key="amenity" value="fast_food" />
         <key key="brand" value="Rostic's" />
+        <key key="brand:wikidata" value="Q3442874" />
+        <key key="brand:wikipedia" value="ru:Ростикс" />
         <key key="contact:vk" value="https://vk.com/rostics_official" />
         <key key="contact:website" value="https://rostics.ru" />
         <key key="cuisine" value="chicken" />
@@ -643,6 +657,7 @@
         <combo key="opening_hours" text="Opening Hours" values="Mo-Su 08:00-22:00,Mo-Th 10:00-22:00; Fr-Su 10:00-23:00" />
         <key key="amenity" value="cafe" />
         <key key="brand" value="Surf Coffee" />
+        <key key="brand:wikidata" value="Q110278756" />
         <key key="contact:email" value="team@surfcoffee.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/surfcoffee.msk/" />
         <key key="contact:website" value="https://www.surfcoffee.ru/" />
@@ -680,6 +695,7 @@
         <combo key="opening_hours" text="Opening Hours" values="Mo-Su 10:00-22:00,Mo-Su 08:00-23:00" />
         <key key="amenity" value="cafe" />
         <key key="brand" value="Даблби" />
+        <key key="brand:wikidata" value="Q62501686" />
         <key key="contact:email" value="info@double-b.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/DoubleBCoffeeTea" />
         <key key="contact:instagram" value="https://www.instagram.com/doublebcoffeetea" />
@@ -699,6 +715,8 @@
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 09:00-23:00,Mo-Su 10:00-23:00,Mo-Su 10:00-22:00" />
         <key key="amenity" value="fast_food" />
         <key key="brand" value="Додо Пицца" />
+        <key key="brand:wikidata" value="Q61949318" />
+        <key key="brand:wikipedia" value="ru:Додо Пицца" />
         <key key="contact:email" value="feedback@dodopizza.com" />
         <key key="contact:facebook" value="https://www.facebook.com/dodopizza/" />
         <key key="contact:instagram" value="https://www.instagram.com/dodopizza" />
@@ -742,6 +760,7 @@
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-23:00,Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" />
         <key key="amenity" value="cafe" />
         <key key="brand" value="Дринкит" />
+        <key key="brand:wikidata" value="Q139554667" />
         <key key="contact:instagram" value="https://www.instagram.com/drinkitcafe" />
         <key key="contact:telegram" value="https://t.me/drinkit_business" />
         <key key="contact:website" value="https://drinkit.ru" />
@@ -868,6 +887,7 @@
         <reference ref="oh3" />
         <key key="amenity" value="fast_food" />
         <key key="brand" value="Правда Кофе" />
+        <key key="brand:wikidata" value="Q139555237" />
         <key key="contact:facebook" value="https://www.facebook.com/pravdacoffee" />
         <key key="contact:instagram" value="https://www.instagram.com/pravda_coffee" />
         <key key="contact:vk" value="https://vk.com/pravda_coffee" />
@@ -889,14 +909,15 @@
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-23:00,Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <key key="amenity" value="fast_food" />
         <key key="brand" value="Робин Сдобин" />
+        <key key="brand:wikidata" value="Q62273880" />
         <key key="contact:email" value="info@robinsdobin.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/robin_sdobin_vrn" />
         <key key="contact:phone" value="+7 800 5505560" />
         <key key="contact:vk" value="https://vk.com/robinsdobin_vrn" />
-        <key key="contact:website" value="https://sdobin.ru" />
+        <key key="contact:website" value="https://robinok.ru" />
         <key key="name" value="Робин Сдобин" />
         <key key="name:ru" value="Робин Сдобин" />
-        <link href="https://sdobin.ru" text="Official website (place locator)" ru.text="Ссылка на сайт (часы работы, координаты и т.п.)" />
+        <link href="https://robinok.ru" text="Official website (place locator)" ru.text="Ссылка на сайт (часы работы, координаты и т.п.)" />
         <reference ref="level_wheelchair_address_wifi_outdoorseating_drivethrough" />
       </item>
       <item name="Russian Appetite" ru.name="Русский Аппетит" type="node,closedway,multipolygon" preset_name_label="true">
@@ -906,15 +927,16 @@
         <reference ref="phone" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-23:00,Mo-Fr 08:00-23:00; Sa-Su 09:00-21:00" />
         <key key="brand" value="Русский Аппетит" />
+        <key key="brand:wikidata" value="Q62086063" />
         <key key="contact:facebook" value="https://www.facebook.com/Русский-Аппетит-1502979646622576" />
         <key key="contact:ok" value="https://ok.ru/profile/583525030934" />
         <key key="contact:twitter" value="https://twitter.com/rusappp" />
         <key key="contact:vk" value="https://vk.com/club10566241" />
-        <key key="contact:website" value="http://xn--80a4abej.xn--p1ai" />
+        <key key="contact:website" value="https://rusapp.ru" />
         <key key="diet:vegetarian" value="no" />
         <key key="name" value="Русский Аппетит" />
         <key key="name:ru" value="Русский Аппетит" />
-        <link href="http://xn--80a4abej.xn--p1ai/karta/" text="Official website (place locator)" ru.text="Ссылка на сайт (часы работы, координаты и т.п.)" />
+        <link href="https://rusapp.ru" text="Official website (place locator)" ru.text="Ссылка на сайт (часы работы, координаты и т.п.)" />
         <reference ref="level_wheelchair_address_wifi_outdoorseating_drivethrough" />
       </item>
       <item name="Stars Coffee" ru.name="Старс Кофе" type="node,closedway,multipolygon" preset_name_label="true">
@@ -923,6 +945,7 @@
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-23:00,Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" />
         <key key="amenity" value="cafe" />
         <key key="brand" value="Stars Coffee" />
+        <key key="brand:wikidata" value="Q117236699" />
         <key key="contact:email" value="info@stars-coffee.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/starscoffee_official" />
         <key key="contact:vk" value="https://vk.com/starscoffee_official" />
@@ -984,6 +1007,8 @@
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-23:00,Mo-Fr 07:00-23:00; Sa-Su 10:00-23:00" />
         <key key="amenity" value="cafe" />
         <key key="brand" value="Шоколадница" />
+        <key key="brand:wikidata" value="Q30891188" />
+        <key key="brand:wikipedia" value="ru:Шоколадница (сеть кофеен)" />
         <key key="contact:facebook" value="https://www.facebook.com/shoko.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/shoko.ru" />
         <key key="contact:ok" value="https://ok.ru/shokoru" />
@@ -1006,6 +1031,7 @@
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-06:00,Mo-Su 10:00-05:00; Mo-Su 11:00-06:00" />
         <key key="amenity" value="restaurant" />
         <key key="brand" value="Якитория" />
+        <key key="brand:wikidata" value="Q66088063" />
         <key key="contact:facebook" value="https://www.facebook.com/yakitoriyacafe" />
         <key key="contact:instagram" value="https://www.instagram.com/yakitoriyacafe" />
         <key key="contact:vk" value="https://vk.com/yakitoriyacafe" />
@@ -1150,6 +1176,8 @@
         <combo key="contact:phone" text="Phone number" values="+7 499 7550070,+7 812 60101000,+7 343 2372246,+7 843 5247545" default="+7 499 7550070" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-23:00,Mo-Su 09:00-22:00" />
         <key key="brand" value="Верный" />
+        <key key="brand:wikidata" value="Q110037370" />
+        <key key="brand:wikipedia" value="ru:Верный (сеть магазинов)" />
         <key key="contact:email" value="info@ivoin.ru" />
         <key key="contact:phone" value="+7 800 2506648" />
         <key key="contact:website" value="https://www.verno-info.ru" />
@@ -1180,6 +1208,8 @@
         <combo key="contact:phone" text="Phone number" default="+7 495 6638602" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 09:00-21:00,Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <key key="brand" value="ВкусВилл" />
+        <key key="brand:wikidata" value="Q57271676" />
+        <key key="brand:wikipedia" value="ru:Вкусвилл" />
         <key key="contact:email" value="info@izbenka.msk.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/vkusvill.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/vkusvill_ru" />
@@ -1198,6 +1228,7 @@
         <reference ref="shop_type" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-22:00,Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <key key="brand" value="ДА!" />
+        <key key="brand:wikidata" value="Q127829045" />
         <key key="contact:ok" value="https://ok.ru/group/53791378178175" />
         <key key="contact:phone" value="+7 495 6644042" />
         <key key="contact:telegram" value="https://t.me/marketda" />
@@ -1233,6 +1264,7 @@
         <combo key="contact:phone" text="Phone number" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-22:00,Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <key key="brand" value="Доброцен" />
+        <key key="brand:wikidata" value="Q136697017" />
         <key key="contact:instagram" value="https://www.instagram.com/dobrotsen.ru/" />
         <key key="contact:vk" value="https://vk.com/dobrotcensklad" />
         <key key="contact:website" value="https://доброцен.рф/" />
@@ -1320,6 +1352,7 @@
         <reference ref="phone" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-22:00,Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <key key="brand" value="Магнолия" />
+        <key key="brand:wikidata" value="Q134561836" />
         <key key="contact:email" value="magnolia@tcfoods.ru" />
         <key key="contact:website" value="http://www.mgnl.ru" />
         <key key="name" value="Магнолия" />
@@ -1332,6 +1365,8 @@
         <reference ref="shop_type" />
         <reference ref="oh3" />
         <key key="brand" value="Мария-Ра" />
+        <key key="brand:wikidata" value="Q4281631" />
+        <key key="brand:wikipedia" value="ru:Мария-Ра" />
         <key key="contact:email" value="ura@maria-ra.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/mariarashop/" />
         <key key="contact:instagram" value="https://www.instagram.com/mariarashop/" />
@@ -1363,6 +1398,7 @@
         <space />
         <combo key="opening_hours" text="Opening Hours" values="Mo-Sa 09:00-21:00; Su 09:00-20:00" />
         <key key="brand" value="Мясницкий ряд" />
+        <key key="brand:wikidata" value="Q126737188" />
         <key key="contact:email" value="info2@kolbasa.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/kolbasaMR" />
         <key key="contact:phone" value="+7 495 9811719" />
@@ -1454,6 +1490,8 @@
         <reference ref="shop_type" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-23:00,Mo-Sa 09:00-20:00; Su 10:00-19:00" default="Mo-Su 09:00-21:00" />
         <key key="brand" value="Светофор" />
+        <key key="brand:wikidata" value="Q61875920" />
+        <key key="brand:wikipedia" value="ru:Светофор (торговая сеть)" />
         <combo key="contact:phone" text="Phone number" />
         <key key="contact:vk" value="https://vk.com/svetofor.market" />
         <key key="contact:website" value="https://svetofor-nsk.ru/" />
@@ -1467,6 +1505,8 @@
         <combo key="contact:phone" text="Phone number" default="+7 499 7544444" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-23:00,Mo-Sa 09:00-20:00; Su 10:00-19:00" default="Mo-Su 10:00-23:00" />
         <key key="brand" value="Суши Wok" />
+        <key key="brand:wikidata" value="Q25444754" />
+        <key key="brand:wikipedia" value="ru:Суши Wok" />
         <key key="contact:facebook" value="https://www.facebook.com/sushiwokofficial" />
         <key key="contact:instagram" value="https://www.instagram.com/sushi_wok" />
         <key key="contact:ok" value="https://ok.ru/group/53844357873904" />
@@ -1498,6 +1538,7 @@
         <reference ref="shop_type" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 09:00-21:00,Mo-Su 10:00-22:00,Mo-Fr 09:00-22:00; Sa-Su 10:00-21:00" />
         <key key="brand" value="Чижик" />
+        <key key="brand:wikidata" value="Q124171414" />
         <key key="contact:ok" value="https://ok.ru/group/59102867030124" />
         <key key="contact:vk" value="https://vk.com/chizhik.club" />
         <key key="contact:website" value="https://chizhik.club/" />
@@ -1511,6 +1552,7 @@
         <space />
         <reference ref="phone" />
         <key key="brand" value="Ярче!" />
+        <key key="brand:wikidata" value="Q102254456" />
         <key key="contact:email" value="feedback@ya-retail.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/Yarche.supermarket/" />
         <key key="contact:instagram" value="https://www.instagram.com/supermarket_yarche" />
@@ -1526,6 +1568,7 @@
         <space />
         <combo key="opening_hours" text="Opening Hours" values="24/7" />
         <key key="brand" value="Около" />
+        <key key="brand:wikidata" value="Q139555162" />
         <key key="contact:email" value="info@okolo.market" />
         <key key="contact:phone" value="+7 800 301-47-33" />
         <key key="contact:website" value="https://okolo.market" />
@@ -1565,6 +1608,7 @@
         <combo key="contact:phone" text="Phone number" default="+7 495 7775190-xxxx" />
         <reference ref="oh3" />
         <key key="brand" value="Ароматный мир" />
+        <key key="brand:wikidata" value="Q109852336" />
         <key key="contact:facebook" value="https://www.facebook.com/amwine.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/amwine.ru" />
         <key key="contact:telegram" value="https://t.me/amwineru" />
@@ -1591,6 +1635,8 @@
         <combo key="contact:phone" text="Phone number" default="+7 800 7071555" />
         <reference ref="oh3" />
         <key key="brand" value="Бристоль" />
+        <key key="brand:wikidata" value="Q59155583" />
+        <key key="brand:wikipedia" value="ru:Бристоль (сеть магазинов)" />
         <key key="contact:facebook" value="https://www.facebook.com/bristolretail" />
         <key key="contact:instagram" value="https://www.instagram.com/bristol_retail" />
         <key key="contact:vk" value="https://vk.com/bristol_retail" />
@@ -1615,6 +1661,7 @@
         <combo key="contact:phone" text="Phone number" default="+7 800 3017755" />
         <reference ref="oh3" />
         <key key="brand" value="Винлаб" />
+        <key key="brand:wikidata" value="Q109907753" />
         <key key="contact:facebook" value="https://www.facebook.com/winelabru" />
         <key key="contact:instagram" value="https://www.instagram.com/winelab.ru" />
         <key key="contact:phone" value="+7 800 3017755" />
@@ -1862,6 +1909,8 @@
         <reference ref="phone" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 09:00-21:00,Mo-Fr 09:00-20:00; Sa-Su 10:00-20:00" default="Mo-Su 09:00-21:00" />
         <key key="brand" value="Ситилинк" />
+        <key key="brand:wikidata" value="Q16698091" />
+        <key key="brand:wikipedia" value="ru:Ситилинк" />
         <key key="contact:instagram" value="https://www.instagram.com/citilink_ru/" />
         <key key="contact:vk" value="https://vk.com/citilink_ru" />
         <key key="contact:facebook" value="https://www.facebook.com/citilink.ru" />
@@ -1903,6 +1952,7 @@
         <reference ref="oh3" />
         <combo key="contact:phone" text="Phone number" values="+7 800 2228000" />
         <key key="brand" value="Boxberry" />
+        <key key="brand:wikidata" value="Q126915345" />
         <key key="contact:facebook" value="https://www.facebook.com/boxberry.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/boxberryclub" />
         <key key="contact:vk" value="https://vk.com/club80315656" />
@@ -2114,6 +2164,8 @@
         <reference ref="oh3" />
         <text key="ref" text="Reference" ru.text="Номер постамата" />
         <key key="brand" value="Утконос" />
+        <key key="brand:wikidata" value="Q4478920" />
+        <key key="brand:wikipedia" value="ru:Утконос Онлайн" />
         <key key="contact:phone" value="+7 495 7775444" />
         <key key="contact:website" value="https://www.utkonos.ru" />
         <key key="name" value="Утконос" />
@@ -2450,6 +2502,7 @@
         <combo key="contact:phone" text="Phone number" values="+7 800 2503344-xxxx" default="+7 800 2503344" />
         <combo key="opening_hours" text="Opening Hours" values="Mo-Su 10:00-22:00,Mo-Su 09:00-21:00" />
         <key key="brand" value="Адамас" />
+        <key key="brand:wikidata" value="Q62393709" />
         <key key="contact:email" value="office@adamas.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/adamas.club" />
         <key key="contact:instagram" value="https://www.instagram.com/adamas_ru" />
@@ -2484,6 +2537,7 @@
         <combo key="contact:phone" text="Phone number" default="+7 800 2500025" />
         <key key="shop" value="hardware" />
         <key key="brand" value="Галамарт" />
+        <key key="brand:wikidata" value="Q109852014" />
         <key key="contact:email" value="info@galamart.ru" />
         <key key="contact:website" value="https://galamart.ru/" />
         <key key="contact:youtube" value="https://www.youtube.com/channel/UCUypd9qxKCCh2h7DeJfRXvQ" />
@@ -2522,6 +2576,7 @@
         <combo key="contact:phone" text="Phone number" default="+7 800 2008227" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-22:00,Mo-Fr 10:00-20:00; Sa-Su 10:00-18:00" />
         <key key="brand" value="Диана" />
+        <key key="brand:wikidata" value="Q62105088" />
         <key key="contact:email" value="diana@dryclean.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/diana.dryclean" />
         <key key="contact:instagram" value="https://www.instagram.com/dryclean.ru" />
@@ -2538,6 +2593,7 @@
         <combo key="contact:phone" text="Phone number" default="+7 800 1000005" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-22:00,Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <key key="brand" value="Иль де Ботэ" />
+        <key key="brand:wikidata" value="Q28942839" />
         <key key="contact:telegram" value="https://t.me/iledebeaute_ru" />
         <key key="contact:vk" value="https://vk.com/iledebeaute" />
         <key key="contact:website" value="https://iledebeaute.ru" />
@@ -2553,6 +2609,7 @@
         <combo key="contact:phone" text="Phone number" values="+7 495 6630343" default="+7 800 7750343" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 08:00-23:00" />
         <key key="brand" value="Кораблик" />
+        <key key="brand:wikidata" value="Q57653416" />
         <key key="contact:email" value="shop@korablik.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/korablik.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/korablik.shop" />
@@ -2631,6 +2688,8 @@
         <space />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-22:00,Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <key key="brand" value="Московский ювелирный завод" />
+        <key key="brand:wikidata" value="Q125181586" />
+        <key key="brand:wikipedia" value="ru:Московский ювелирный завод" />
         <key key="contact:email" value="client@miuz.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/miuz.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/miuz_ru" />
@@ -2665,7 +2724,9 @@
         <reference ref="phone" />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-22:00,Mo-Fr 08:00-22:00; Sa-Su 09:00-21:00" />
         <key key="brand" value="Персона" />
-        <!-- <key key="contact:facebook" value="https://www.facebook.com/ipersona" /> NB: указан на официальном сайте, но в фб такой страницы нет -->
+        <key key="brand:wikidata" value="Q126163981" />
+        <key key="contact:facebook" value="https://www.facebook.com/agencypersona" />
+        <key key="contact:instagram" value="https://www.instagram.com/persona.original" />
         <key key="contact:twitter" value="https://twitter.com/Persona_PR" />
         <key key="contact:vk" value="https://vk.com/lab_persona" />
         <key key="contact:website" value="https://persona.ru" />
@@ -2679,6 +2740,7 @@
         <space />
         <combo key="opening_hours" text="Opening Hours" values="Mo-Su 10:00-22:00,Mo-Su 09:00-21:00" default="Mo-Su 09:00-21:00" />
         <key key="brand" value="Подружка" />
+        <key key="brand:wikidata" value="Q101646588" />
         <key key="contact:email" value="secretary@taber.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/podrygkashop" />
         <key key="contact:instagram" value="https://www.instagram.com/podrygkashop" />
@@ -2695,7 +2757,6 @@
       <item name="Smeshnie Tseni" ru.name="Смешные цены" type="node,closedway,multipolygon" preset_name_label="true">
         <space />
         <key key="brand" value="Смешные цены" />
-        <!-- <key key="contact:website" value="http://smeshnyeceny.ru" /> NOTE: старый сайт, но всё ещё рабочий -->
         <key key="contact:website" value="https://smeshnie-ceny.ru" />
         <key key="name" value="Смешные цены" />
         <key key="name:ru" value="Смешные цены" />
@@ -2707,6 +2768,8 @@
         <space />
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 10:00-22:00,Mo-Su 10:00-20:00" />
         <key key="brand" value="Спортмастер" />
+        <key key="brand:wikidata" value="Q4438176" />
+        <key key="brand:wikipedia" value="ru:Спортмастер" />
         <key key="contact:email" value="e-commerce@sportmaster.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/sportmaster.ru" />
         <key key="contact:instagram" value="https://www.instagram.com/sportmaster_official" />
@@ -2732,6 +2795,7 @@
         <combo key="opening_hours" text="Opening Hours" values="Mo-Su 10:00-22:00,Mo-Su 10:00-23:00,Mo-Su 09:00-21:00,Mo-Su 09:00-22:00" />
         <key key="alt_name" value="Твое" />
         <key key="brand" value="ТВОЁ" />
+        <key key="brand:wikidata" value="Q110034939" />
         <key key="contact:email" value="help@tvoe.ru" />
         <key key="contact:facebook" value="https://www.facebook.com/odezda.tvoe" />
         <key key="contact:instagram" value="https://www.instagram.com/tvoe_official" />
@@ -2751,6 +2815,7 @@
         <combo key="contact:phone" text="Phone number" default="+7 800 3336600" />
         <combo key="opening_hours" text="Opening Hours" values="Mo-Su 10:00-20:00,Mo-Su 10:00-22:00,Mo-Su 09:00-20:00,Mo-Su 09:00-21:00" />
         <key key="brand" value="Улыбка радуги" />
+        <key key="brand:wikidata" value="Q109734104" />
         <key key="contact:instagram" value="https://www.instagram.com/ulybkaradugi" />
         <key key="contact:vk" value="https://vk.com/ulybka_radugi" />
         <key key="contact:website" value="https://www.r-ulybka.ru" />
@@ -2920,6 +2985,7 @@
         <combo key="opening_hours" text="Opening Hours" values="24/7,Mo-Su 09:00-21:00,Mo-Fr 10:00-21:00; Sa-Su 10:00-20:00,Mo-Th 09:00-13:00\,13:45-17:00; Fr 09:00-13:00\,13:45-15:45" />
         <key key="amenity" value="public_service" />
         <key key="brand" value="Мои документы" />
+        <key key="brand:wikidata" value="Q57449742" />
         <key key="government" value="public_service" />
         <key key="office" value="government" />
         <key key="short_name" value="МФЦ" />
@@ -3522,6 +3588,7 @@
         <key key="amenity" value="vending_machine" />
         <key key="vending" value="water" />
         <key key="brand" value="Живая вода" />
+        <key key="brand:wikidata" value="Q125924184" />
         <key key="contact:website" value="https://alivewater.ru/" />
         <key key="opening_hours" value="24/7" />
         <key key="name" value="Живая вода" />


### PR DESCRIPTION
Добавил теги brand:wikidata и brand:wikipedia и обновил старые ссылки

Спорные моменты:
- Добавление brand:wikidata=[Q109810737](https://www.wikidata.org/wiki/Q109810737) при разных значениях `brand`(`Вита`,`Вита Экспресс`,`Вита Центральная`)
- Boxberry - я без понятия в каком он сейчас состоянии после покупки яндексом

Ещё такой вопрос: А надо ли менять version как сказано в README, но который не менялся с 24 года?
